### PR TITLE
feat: add error when labelMap is no match

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ const cocoDataAccess: DataAccessType = async (args: ArgsType): Promise<CocoDatas
   if (testPair.length > 0) {
     result.testLoader = testLoader;
   }
-  
+
   return result;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ const getValidPair = async (dataPath: string, labelMap: Record<string, number>) 
       cocoJson.images.push(imageItem);
       imageData.annotation.object.forEach((object: any) => {
         if (typeof labelMap[object.name[0]] === 'undefined') {
-          throw `category: ${object.name[0]} is not match with train/*.xml (from ${fileName})`
+          throw new TypeError(`category: ${object.name[0]} is not match with train/*.xml (from ${fileName})`);
         }
         const label: ImageLabel = {
           name: object.name[0],

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,9 @@ const getValidPair = async (dataPath: string, labelMap: Record<string, number>) 
     if (fs.existsSync(path.join(dataPath, imageName))) {
       cocoJson.images.push(imageItem);
       imageData.annotation.object.forEach((object: any) => {
+        if (typeof labelMap[object.name[0]] === 'undefined') {
+          throw `category: ${object.name[0]} is not match with train/*.xml (from ${fileName})`
+        }
         const label: ImageLabel = {
           name: object.name[0],
           categoryId: labelMap[object.name[0]]
@@ -223,7 +226,7 @@ const cocoDataAccess: DataAccessType = async (args: ArgsType): Promise<CocoDatas
   if (testPair.length > 0) {
     result.testLoader = testLoader;
   }
-
+  
   return result;
 };
 


### PR DESCRIPTION
新增识别category与labelMap不匹配的逻辑，防止花费大量时间对模型进行训练后才发现报错